### PR TITLE
Use the HTTPS connection to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects  {
 	targetCompatibility = 1.8
 
 	repositories {
-		maven { url "http://repo.maven.apache.org/maven2" }
+		maven { url "https://repo.maven.apache.org/maven2" }
 	}
 }
 


### PR DESCRIPTION
This is required since Jan 15: https://blog.sonatype.com/central-repository-moving-to-https

---

This change is all I need to get this to build.